### PR TITLE
fix #2 added fastMapDouble class

### DIFF
--- a/FastMap.cpp
+++ b/FastMap.cpp
@@ -1,17 +1,18 @@
 //
 //    FILE: FastMap.cpp
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.2.1
+// VERSION: 0.3.0
 // PURPOSE: class with fast map function - library for Arduino
 //     URL: https://github.com/RobTillaart/FastMap
 //
 // HISTORY:
+// 0.3.0  2020-07-04 added fastMapDouble + test sketch.
 // 0.2.1  2020-06-10 fix library.json; rename license
 // 0.2.0  2020-03-21 #pragma once; readme.md; license.md
 //
 // 0.1.8  2017-07-27 revert double to float (issue 33)
 // 0.1.7  2017-04-28 cleaned up, get examples working again
-// 0.1.06 2015-03-08 replaced float by float (support ARM)
+// 0.1.06 2015-03-08 replaced float by double (support ARM)
 // 0.1.05 2014-11-02 stripped of bit mask experimental code
 // 0.1.04 add back() - the inverse map
 //        tested with bit mask for constrain code (Perfomance was killed)
@@ -23,10 +24,6 @@
 
 #include "FastMap.h"
 
-/////////////////////////////////////////////////////
-//
-// PUBLIC
-//
 FastMap::FastMap()
 {
     init(0, 1, 0, 1);
@@ -60,6 +57,44 @@ float FastMap::lowerConstrainedMap(float value)
 }
 
 float FastMap::upperConstrainedMap(float value)
+{
+    if (value >= _in_max) return _out_max;
+    return this->map(value);
+}
+
+FastMapDouble::FastMapDouble()
+{
+    init(0, 1, 0, 1);
+}
+
+void FastMapDouble::init(double in_min, double in_max, double out_min, double out_max)
+{
+    _in_min = in_min;
+    _in_max = in_max;
+    _out_min = out_min;
+    _out_max = out_max;
+
+    _factor = (out_max - out_min)/(in_max - in_min);
+    _base = out_min - in_min * _factor;
+
+    _backfactor = 1/_factor;
+    _backbase = in_min - out_min * _backfactor;
+}
+
+double FastMapDouble::constrainedMap(double value)
+{
+    if (value <= _in_min) return _out_min;
+    if (value >= _in_max) return _out_max;
+    return this->map(value);
+}
+
+double FastMapDouble::lowerConstrainedMap(double value)
+{
+    if (value <= _in_min) return _out_min;
+    return this->map(value);
+}
+
+double FastMapDouble::upperConstrainedMap(double value)
 {
     if (value >= _in_max) return _out_max;
     return this->map(value);

--- a/FastMap.h
+++ b/FastMap.h
@@ -2,7 +2,7 @@
 //
 //    FILE: FastMap.h
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.2.1
+// VERSION: 0.3.0
 // PURPOSE: class with fast map function - library for Arduino
 //     URL: https://github.com/RobTillaart/FastMap
 //
@@ -12,7 +12,7 @@
 
 #include <Arduino.h>
 
-#define FASTMAP_LIB_VERSION (F("0.2.1"))
+#define FASTMAP_LIB_VERSION (F("0.3.0"))
 
 class FastMap
 {
@@ -34,4 +34,26 @@ private:
     float _backfactor, _backbase;
 };
 
-// END OF FILE
+
+class FastMapDouble
+{
+public:
+    FastMapDouble();
+    void init(const double in_min, const double in_max, const double out_min, const double out_max);
+
+    double inline map (const double value)  { return _base + value * _factor; }
+    double inline back (const double value) { return _backbase + value * _backfactor; }
+
+    double constrainedMap(const double value);
+    double lowerConstrainedMap(const double value);
+    double upperConstrainedMap(const double value);
+
+private:
+    double _in_min, _in_max, _out_min, _out_max;
+    double _factor, _base;
+    double _backfactor, _backbase;
+};
+
+
+
+// -- END OF FILE --

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2010-2020 Rob Tillaart
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,42 @@
 # FastMap
+
 Fast mapping and constraining
 
 ## Description
-FastMap is an object that precalculates (internal) floats
-to make the mapping function a.k.a. map() much faster. 
-The implementation uses floats to minimize the operation, 
-which might result in more memory usage.
+FastMap is an object that precalculates (internal) floats to make the mapping function a.k.a. map() much faster.
+The preformance is the result of precalculate float values so actual mapping only has one multiply and add.
+The implementation uses floats which might result in more memory usage and some loss of precision for mapping
+with larger values.
 
-Besides the **FastMap.map(value)** FastMap also has a **FastMap.back(value)** function to 'map in reverse'.
+Note the gain is only made when there are many calls to the same mapping.
+If one alternates between different mappings it is better to create multiple fastMap objects.
+
+The **init()** function calculates all needed values for the fastMapping and the constrains.
+Note this function can be called again with new values when needed to do other mapping.
+
+- **init(in_min, in_max, out_min, out_max);** defines the linear mapping parameters.
+
+
+Besides the **map(value)** FastMap also has a **back(value)** function to 'map in reverse'.
 
 FastMap supports three versions of constraining the map function, as constrain() and map() often used together. 
-- **FastMap.constrainedMap(value);**
-- **FastMap.lowerConstrainedMap(value);**
-- **FastMap.upperConstrainedMap(value);**
+- **constrainedMap(value);** will return a value between outMin .. outMax
+- **lowerConstrainedMap(value);** will return a value between outMin .. inf  (No upper limit)
+- **upperConstrainedMap(value);** will return a value between -inf .. outMax
 
-Note there are **no** constrain-versions for **FastMap.back(value)**
+To change the constrain values call **init()** with new limits, or call the original constrain()
+
+Note there are **no** constrain-versions for **back(value)**
+
+## FastMapDouble
+
+Version 3.0 adds **fastMapDouble** which has the same interface.
+This additional class is meant to support 8 bytes doubles in their 
+native accuracy and precision. 
+To display doubles one might need the **sci()** function of my **printHelpers** class.
 
 ## Usage
+
 When a sensor has to be read out frequently and one needs to map the 
 value to another value e.g. to display or as control signal, the normal map() 
 function is using more math operations than **FastMap.map()**

--- a/examples/constrainedMapDemo/constrainedMapDemo.ino
+++ b/examples/constrainedMapDemo/constrainedMapDemo.ino
@@ -4,10 +4,7 @@
 // VERSION: 0.1.1
 // PURPOSE: demo of FastMap class ==> merge map and constrain functions
 //    DATE: 2014-11-02
-//     URL: 
-//
-// Released to the public domain
-//
+//     URL: https://github.com/RobTillaart/FastMap
 
 #include "FastMap.h"
 

--- a/examples/fastMapDemo/fastMapDemo.ino
+++ b/examples/fastMapDemo/fastMapDemo.ino
@@ -4,10 +4,7 @@
 // VERSION: 0.1.02
 // PURPOSE: demo of FastMap class ==> a faster map function
 //    DATE: 2014-11-02
-//     URL:
-//
-// Released to the public domain
-//
+//     URL: https://github.com/RobTillaart/FastMap
 
 #include "FastMap.h"
 

--- a/examples/fastMapDemo2/fastMapDemo2.ino
+++ b/examples/fastMapDemo2/fastMapDemo2.ino
@@ -4,10 +4,7 @@
 // VERSION: 0.1.02
 // PURPOSE: demo of FastMap class ==> a faster map function
 //    DATE: 2014-11-02
-//     URL:
-//
-// Released to the public domain
-//
+//     URL: https://github.com/RobTillaart/FastMap
 
 #include "FastMap.h"
 

--- a/examples/fastMapDemo3/fastMapDemo3.ino
+++ b/examples/fastMapDemo3/fastMapDemo3.ino
@@ -3,10 +3,8 @@
 // VERSION: 0.1.1
 // PURPOSE: demo of FastMap class ==> a faster map function
 //    DATE: 2014-11-02
-//     URL: http://forum.arduino.cc/index.php?topic=276194
-//
-// Released to the public domain
-//
+//     URL: https://github.com/RobTillaart/FastMap
+//          http://forum.arduino.cc/index.php?topic=276194
 
 #include "FastMap.h"
 

--- a/examples/fastMapDemo4/fastMapDemo4.ino
+++ b/examples/fastMapDemo4/fastMapDemo4.ino
@@ -1,15 +1,10 @@
 //
 //    FILE: fastMapDemo4.ino
 //  AUTHOR: Rob Tillaart
-// VERSION: 0.1.00
+// VERSION: 0.1.0
 // PURPOSE: demo of FastMap class ==> a faster map function
 //    DATE: 2014-11-02
-//     URL:
-//
-// Released to the public domain
-//
-
-// works only with 0.1.04
+//     URL: https://github.com/RobTillaart/FastMap
 
 #include "FastMap.h"
 

--- a/keywords..txt
+++ b/keywords..txt
@@ -2,6 +2,7 @@
 
 # Datatypes (KEYWORD1)
 FastMap	KEYWORD1
+FastMapDouble	KEYWORD1
 
 # Methods and Functions (KEYWORD2)
 map	KEYWORD2

--- a/library.json
+++ b/library.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/RobTillaart/FastMap"
   },
-  "version":"0.2.1",
+  "version":"0.3.0",
   "frameworks": "arduino",
   "platforms": "*"
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=FastMap
-version=0.2.1
+version=0.3.0
 author=Rob Tillaart <rob.tillaart@gmail.com>
 maintainer=Rob Tillaart <rob.tillaart@gmail.com>
 sentence=Library with fast map function for Arduino. 


### PR DESCRIPTION
Added a identical fastMapDouble class to allow mapping to work with 8 byte doubles when needed.
This class is functional identical to fastMap. 